### PR TITLE
Use excerpt for tooltip instead of whole content

### DIFF
--- a/php/gb-fc-ajax.php
+++ b/php/gb-fc-ajax.php
@@ -111,7 +111,7 @@ class GbFcAjax
             if ($post->post_type == 'attachment') {
                 $content->imageUrl = wp_get_attachment_image_url($post->ID, 'thumbnail');
             } else {
-                $content->excerpt = (!empty($post)) ? $post->post_content : '';
+                $content->excerpt = (!empty($post)) ? $post->post_excerpt : '';
                 if (get_option('gbfc_tooltipImage', true)) {
                     $post_image_url = get_the_post_thumbnail_url($post->ID);
                     if (!empty($post_image_url)) {


### PR DESCRIPTION
Currently the whole description of an event is used for the tooltip. Usually that's too much content. The tooltip should only show the excerpt of the event.